### PR TITLE
Set user status default to 0 (off)

### DIFF
--- a/priv/repo/migrations/20181018220010_update_users_table.exs
+++ b/priv/repo/migrations/20181018220010_update_users_table.exs
@@ -1,0 +1,9 @@
+defmodule Qms.Repo.Migrations.UpdateUsersTable do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      modify :status, :integer, default: 0
+    end
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -11,4 +11,4 @@
 # and so on) as they will fail if something goes wrong.
 
 Qms.Repo.insert(%Qms.User{slack_user_id: "12345"}, on_conflict: :nothing)
-Qms.Repo.insert(%Qms.User{slack_user_id: "23456", status: 0}, on_conflict: :nothing)
+Qms.Repo.insert(%Qms.User{slack_user_id: "23456", status: 1}, on_conflict: :nothing)


### PR DESCRIPTION
When a user is added, it is assumed that they haven't connected their spotify account yet, so we will set their user status to 0.

### Considerations

* Being an MVP, the status of the user is coupled to the spotify authentication, but it can be refactored later when the complexity grows.