### PR TITLE
House keeping on application.

### DIFF
--- a/lib/qms/spotify/auth.ex
+++ b/lib/qms/spotify/auth.ex
@@ -4,7 +4,7 @@ defmodule Qms.Spotify.Auth do
   def generate_url(auth_token) do
     @spotify_host
     |> with_param("response_type", "code", "?")
-    |> with_param("client_id", Application.get_env(:qms, "SPOTIFY_CLIENT_ID"))
+    |> with_param("client_id", System.get_env("SPOTIFY_CLIENT_ID"))
     |> with_param("redirect_url", redirect_url_with_auth_token(auth_token))
   end
 
@@ -13,7 +13,7 @@ defmodule Qms.Spotify.Auth do
   end
 
   defp redirect_url_with_auth_token(auth_token) do
-    Application.get_env(:qms, "SPOTIFY_REDIRECT_URI")
+    System.get_env("SPOTIFY_REDIRECT_URI")
       |> String.replace("%auth_token%", auth_token)
   end
 end

--- a/lib/qms_web/controllers/auth_controller.ex
+++ b/lib/qms_web/controllers/auth_controller.ex
@@ -22,7 +22,7 @@ defmodule QmsWeb.AuthController do
   # Private
 
   defp set_user_temp_token(user) do
-    result = Ecto.Changeset.change(user, temp_auth_token: UUID.uuid1())
+    result = Ecto.Changeset.change(user, temp_auth_token: Ecto.UUID.generate)
               |> Repo.insert_or_update
 
     case result do

--- a/mix.exs
+++ b/mix.exs
@@ -40,8 +40,7 @@ defmodule Qms.Mixfile do
       {:phoenix_html, "~> 2.10"},
       {:phoenix_live_reload, "~> 1.0", only: :dev},
       {:gettext, "~> 0.11"},
-      {:cowboy, "~> 1.0"},
-      {:elixir_uuid, "~> 1.2"}
+      {:cowboy, "~> 1.0"}
     ]
   end
 

--- a/priv/repo/migrations/20181110085737_update_users_table_2.exs
+++ b/priv/repo/migrations/20181110085737_update_users_table_2.exs
@@ -3,7 +3,7 @@ defmodule Qms.Repo.Migrations.UpdateUsersTable2 do
 
   def up do
     alter table(:users) do
-      add :temp_auth_token, :binary
+      add :temp_auth_token, :uuid
       remove :spotify_token_expiration
       add :spotify_token_expiration, :utc_datetime
     end

--- a/test/qms/spotify/auth_test.exs
+++ b/test/qms/spotify/auth_test.exs
@@ -9,7 +9,7 @@ defmodule Qms.Spotify.AuthTest do
   end
 
   test "it generates a spotify auth url" do
-    token = UUID.uuid1()
+    token = Ecto.UUID.generate
     auth_url = Auth.generate_url(token)
     expected_url = "https://accounts.spotify.com/authorize?response_type=code&client_id=12345&redirect_url=http://example.com?token=#{token}"
 

--- a/test/qms/spotify/auth_test.exs
+++ b/test/qms/spotify/auth_test.exs
@@ -4,8 +4,8 @@ defmodule Qms.Spotify.AuthTest do
   alias Qms.Spotify.Auth
 
   setup do
-    Application.put_env(:qms, "SPOTIFY_REDIRECT_URI", "http://example.com?token=%auth_token%")
-    Application.put_env(:qms, "SPOTIFY_CLIENT_ID", "12345")
+    System.put_env("SPOTIFY_REDIRECT_URI", "http://example.com?token=%auth_token%")
+    System.put_env("SPOTIFY_CLIENT_ID", "12345")
   end
 
   test "it generates a spotify auth url" do

--- a/test/qms_web/controllers/auth_controller_test.exs
+++ b/test/qms_web/controllers/auth_controller_test.exs
@@ -2,8 +2,8 @@ defmodule QmsWeb.AuthControllerTest do
   use QmsWeb.ConnCase
 
   setup do
-    Application.put_env(:qms, "SPOTIFY_REDIRECT_URI", "http://example.com?token=%auth_token%")
-    Application.put_env(:qms, "SPOTIFY_CLIENT_ID", "12345")
+    System.put_env("SPOTIFY_REDIRECT_URI", "http://example.com?token=%auth_token%")
+    System.put_env("SPOTIFY_CLIENT_ID", "12345")
   end
 
   describe "create/2" do


### PR DESCRIPTION
A few minor issues was causing the app to break down.

1. Migration had broken the db column type. 
2. Application.get_env had effects that were undesired and uncaught due to env variables being mocked in test.

### Considerations

* Logic may need to be split out of the controller soon. Will be a cleanup job once regression tests are done.